### PR TITLE
Laravel database 5.8

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -15,7 +15,10 @@ return [
 
     'providers' => [
         'Illuminate\Database\MigrationServiceProvider',
-        'Illuminate\Database\SeedServiceProvider',
+        /*
+         * Missing class in Illuminate\Database 5.8
+         */
+        //'Illuminate\Database\SeedServiceProvider',
         /*
          * To add Redis support,
          *     - run composer require illuminate/redis:5.2.*

--- a/bootstrap/Console/Artisan.php
+++ b/bootstrap/Console/Artisan.php
@@ -60,7 +60,7 @@ class Artisan extends \Illuminate\Console\Application
             /** @var Application $app */
             $app = Facade::getFacadeApplication();
             /** @var Artisan $console */
-            with($console = new static($app, $app['events'], '5.2.*'))
+            with($console = new static($app, $app['events'], '5.8.*'))
                 //->setExceptionHandler($app['exception'])
                 ->setAutoExit(false);
 
@@ -73,7 +73,7 @@ class Artisan extends \Illuminate\Console\Application
             $console->add(new EnvironmentCommand());
             $console->add(new VendorPublishCommand($app['files']));
 
-            $app['events']->fire(new ArtisanStarting($console));
+            $app['events']->dispatch(new ArtisanStarting($console));
             static::$instance = $console;
         }
 

--- a/bootstrap/Console/Artisan.php
+++ b/bootstrap/Console/Artisan.php
@@ -5,6 +5,17 @@ use Bootstrap\Container\Application;
 use Illuminate\Console\Events\ArtisanStarting;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Console\Migrations\FreshCommand;
+use Illuminate\Database\Console\Migrations\InstallCommand;
+use Illuminate\Database\Console\Migrations\MigrateCommand;
+use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
+use Illuminate\Database\Console\Migrations\RefreshCommand;
+use Illuminate\Database\Console\Migrations\ResetCommand;
+use Illuminate\Database\Console\Migrations\RollbackCommand;
+use Illuminate\Database\Console\Migrations\StatusCommand;
+use Illuminate\Database\Console\Seeds\SeedCommand;
+use Illuminate\Database\Console\Seeds\SeederMakeCommand;
+use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Facade;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -72,6 +83,20 @@ class Artisan extends \Illuminate\Console\Application
             $console->add(new CommandMakeCommand($app['files']));
             $console->add(new EnvironmentCommand());
             $console->add(new VendorPublishCommand($app['files']));
+
+            // DB Migration Commands
+            $console->add(new InstallCommand(new DatabaseMigrationRepository($app['db'], "migrations")));
+            $console->add(new MigrateCommand($app['migrator']));
+            $console->add(new MigrateMakeCommand($app['migration.creator'], $app['composer']));
+            $console->add(new StatusCommand($app['migrator']));
+            $console->add(new RefreshCommand());
+            $console->add(new ResetCommand($app['migrator']));
+            $console->add(new RollbackCommand($app['migrator']));
+            $console->add(new FreshCommand());
+
+            // DB Seed Commands
+            $console->add(new SeedCommand($app['db']));
+            $console->add(new SeedMakeCommand($app['files'], $app['composer']));
 
             $app['events']->dispatch(new ArtisanStarting($console));
             static::$instance = $console;

--- a/bootstrap/Console/AutoloadCommand.php
+++ b/bootstrap/Console/AutoloadCommand.php
@@ -40,7 +40,7 @@ class AutoloadCommand extends Command {
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->composer->dumpOptimized();
         foreach ($this->findWorkbenches() as $workbench)

--- a/bootstrap/Console/CommandMakeCommand.php
+++ b/bootstrap/Console/CommandMakeCommand.php
@@ -39,7 +39,7 @@ class CommandMakeCommand extends Command {
 	 *
 	 * @return void
 	 */
-	public function fire()
+	public function handle()
 	{
 		$path = $this->getPath();
 

--- a/bootstrap/Console/EnvironmentCommand.php
+++ b/bootstrap/Console/EnvironmentCommand.php
@@ -23,7 +23,7 @@ class EnvironmentCommand extends Command {
 	 *
 	 * @return void
 	 */
-	public function fire()
+	public function handle()
 	{
 		$this->line('<info>Current application environment:</info> <comment>'.$this->laravel['env'].'</comment>');
 	}

--- a/bootstrap/Console/ModelMakeCommand.php
+++ b/bootstrap/Console/ModelMakeCommand.php
@@ -43,7 +43,7 @@ class ModelMakeCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $path = $this->getPath();
 

--- a/bootstrap/Console/SeedMakeCommand.php
+++ b/bootstrap/Console/SeedMakeCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+
+namespace Bootstrap\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Composer;
+
+class SeedMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:seed';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new seeder class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Seeder';
+
+    /**
+     * The Composer instance.
+     *
+     * @var Composer
+     */
+    protected $composer;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param Filesystem $files
+     * @param Composer $composer
+     * @return void
+     */
+    public function __construct(Filesystem $files, Composer $composer)
+    {
+        parent::__construct($files);
+
+        $this->composer = $composer;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     * @throws FileNotFoundException
+     */
+    public function handle()
+    {
+        parent::handle();
+
+        $this->composer->dumpAutoloads();
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/seeder.stub';
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return $this->laravel->databasePath().'/seeds/'.$name.'.php';
+    }
+
+    /**
+     * Parse the class name and format according to the root namespace.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function qualifyClass($name)
+    {
+        return $name;
+    }
+
+    /**
+     * Get the model for the default guard's user provider.
+     *
+     * @return string|null
+     */
+    protected function userProviderModel()
+    {
+        return null;
+    }
+}

--- a/bootstrap/Console/ServeCommand.php
+++ b/bootstrap/Console/ServeCommand.php
@@ -27,7 +27,7 @@ class ServeCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->checkPhpVersion();
 

--- a/bootstrap/Console/TinkerCommand.php
+++ b/bootstrap/Console/TinkerCommand.php
@@ -33,7 +33,7 @@ class TinkerCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->getApplication()->setCatchExceptions(false);
         $config = new Configuration;

--- a/bootstrap/Console/VendorPublishCommand.php
+++ b/bootstrap/Console/VendorPublishCommand.php
@@ -50,7 +50,7 @@ class VendorPublishCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $tags = $this->option('tag');
 

--- a/bootstrap/Console/stubs/command.stub
+++ b/bootstrap/Console/stubs/command.stub
@@ -35,7 +35,7 @@ class {{class}} extends Command {
 	 *
 	 * @return mixed
 	 */
-	public function fire()
+	public function handle()
 	{
 		//
 	}

--- a/bootstrap/Console/stubs/seeder.stub
+++ b/bootstrap/Console/stubs/seeder.stub
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class DummyClass extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/bootstrap/Container/Application.php
+++ b/bootstrap/Container/Application.php
@@ -7,7 +7,7 @@ use Closure;
 class Application extends Container
 {
 
-    const VERSION = 5.2;
+    const VERSION = 5.8;
     
     /**
      * The base path of the application installation.

--- a/bootstrap/Container/Application.php
+++ b/bootstrap/Container/Application.php
@@ -189,4 +189,14 @@ class Application extends Container
     {
         $this['exception']->error($callback);
     }
+
+    /**
+     * Get Application Namespace
+     *
+     * @return int|string
+     */
+    public function getNamespace()
+    {
+        return getAppNamespace();
+    }
 } 

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -119,6 +119,20 @@ if (!function_exists('config_path')) {
     }
 }
 
+if (!function_exists('getAppNamespace')) {
+
+    function getAppNamespace()
+    {
+        $composer = json_decode(file_get_contents(BASE . '/composer.json'), true);
+        foreach ((array)data_get($composer, 'autoload.psr-4') as $namespace => $path) {
+            foreach ((array)$path as $pathChoice) {
+                if (realpath(BASE . '/' . 'bootstrap') == realpath(BASE . '/' . $pathChoice))
+                    return $namespace;
+            }
+        }
+        throw new RuntimeException("Unable to detect application namespace.");
+    }
+}
 
 $app = new Application();
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "laravel/database",
-    "description": "Get Laravel 5.2.x database for your non laravel projects. Built on top of illuminate/database to provide migration, seeding and artisan support",
+    "description": "Get Laravel 5.8.x database for your non laravel projects. Built on top of illuminate/database to provide migration, seeding and artisan support",
     "keywords": ["laravel", "database", "sql", "orm"],
     "minimum-stability": "dev",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -12,20 +12,20 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "illuminate/database": "5.2.*",
-        "illuminate/events": "5.2.*",
-        "illuminate/cache": "5.2.*",
-        "illuminate/filesystem": "5.2.*",
+        "php": "^7.1.3",
+        "illuminate/database": "5.8.*",
+        "illuminate/events": "5.8.*",
+        "illuminate/cache": "5.8.*",
+        "illuminate/filesystem": "5.8.*",
         "luracast/config": "2.*",
         "vlucas/phpdotenv": "~1.0",
         "league/flysystem": "~1.0",
-        "illuminate/pagination": "5.2.*"
+        "illuminate/pagination": "5.8.*"
     },
     "require-dev": {
-        "illuminate/console": "5.2.*",
-        "psy/psysh": "0.7.*",
-        "symfony/process": "3.0.*"
+        "illuminate/console": "5.8.*",
+        "psy/psysh": "0.9.*",
+        "symfony/process": "^4.2"
     },
     "suggest": {
         "doctrine/dbal": "Allow renaming columns and dropping SQLite columns."


### PR DESCRIPTION
1. Upgraded all Laravel components to 5.8.*
2. Change the command's fire() method to handle() according to the change log provided on Laravel Website
3. SeedServiceProvider class is removed in the 5.8.*
4. Register migration and seed commands in registerCommands() has been removed in 5.8.* so added them in bootstrap/Console/Artisan.php 